### PR TITLE
convert an empty string ("") to null

### DIFF
--- a/src/main/java/com/orangesignal/csv/bean/SimpleCsvValueConverter.java
+++ b/src/main/java/com/orangesignal/csv/bean/SimpleCsvValueConverter.java
@@ -99,16 +99,17 @@ public class SimpleCsvValueConverter implements CsvValueConverter {
 			throw new IllegalArgumentException("Class must not be null");
 		}
 
-		if (str == null) {
+		if (type.equals(String.class)) {
+			return str;
+		}
+
+		if (str == null || str.length() == 0) {
 			if (type.isPrimitive()) {
 				return PRIMITIVE_DEFAULTS.get(type);
 			}
 			return null;
 		}
-		if (type.equals(String.class)) {
-			return str;
-		}
-
+		
 		if (type.equals(Boolean.TYPE) || type.equals(Boolean.class)) {
 			for (final Map.Entry<String, Boolean> entry : BOOLEAN_DEFAULTS.entrySet()) {
 				if (entry.getKey().equalsIgnoreCase(str)) {


### PR DESCRIPTION
 fix #34 instead of throwing IllegalArgumentException, convert an empty string ("") to null if its type is not primitive.