### PR TITLE
列全体を囲み文字で囲むアノテーションとポリシーを追加

### DIFF
--- a/src/main/java/com/orangesignal/csv/CsvWriter.java
+++ b/src/main/java/com/orangesignal/csv/CsvWriter.java
@@ -139,6 +139,31 @@ public class CsvWriter implements Closeable, Flushable {
 	 * @throws IOException 入出力エラーが発生した場合
 	 */
 	public void writeValues(final List<String> values) throws IOException {
+		writeValuesCore(values, null);
+	}
+
+	/**
+	 * 指定された CSV トークンの値リストを書き込みます。
+	 *
+	 * @param values 書き込む CSV トークンの値リスト
+	 * @param quotes 列全体を囲み文字で囲むかどうかのリスト
+	 * @throws CsvValueException 可変項目数が禁止されている場合に項目数が一致しない場合
+	 * @throws IOException 入出力エラーが発生した場合
+	 * @since 2.2
+	 */
+	public void writeValues(final List<String> values, final List<Boolean> quotes) throws IOException {
+		writeValuesCore(values, quotes);
+	}
+
+	/**
+	 * 指定された CSV トークンの値リストを書き込みます。
+	 *
+	 * @param values 書き込む CSV トークンの値リスト
+	 * @param quotes 列全体を囲み文字で囲むかどうかのリスト
+	 * @throws CsvValueException 可変項目数が禁止されている場合に項目数が一致しない場合
+	 * @throws IOException 入出力エラーが発生した場合
+	 */
+	private void writeValuesCore(final List<String> values, List<Boolean> quotes) throws IOException {
 		synchronized (this) {
 			ensureOpen();
 
@@ -150,11 +175,19 @@ public class CsvWriter implements Closeable, Flushable {
 			final StringBuilder buf = new StringBuilder();
 			if (values != null) {
 				final int max = values.size();
+
+				if (quotes == null) {
+					quotes = new ArrayList<Boolean>();
+					for (int i = 0; i < max; i++) {
+						quotes.add(false);
+					}
+				}
+
 				for (int i = 0; i < max; i++) {
 					if (i > 0) {
 						buf.append(cfg.getSeparator());
 					}
-	
+
 					String value = values.get(i);
 					boolean enclose = false;	// 項目を囲み文字で囲むかどうか
 					if (value == null) {
@@ -168,6 +201,18 @@ public class CsvWriter implements Closeable, Flushable {
 						switch (cfg.getQuotePolicy()) {
 							case ALL:
 								enclose = true;
+								break;
+
+							case COLUMN:
+								// CsvColumn の columnQuote が true の場合に列全体を囲み文字で囲みます。
+								if (quotes.get(i)) {
+									enclose = true;
+								} else {
+									// 項目値に区切り文字、囲み文字、改行文字のいずれかを含む場合は囲み文字で囲むべきと判断します。
+									enclose = value.indexOf(cfg.getSeparator()) != -1
+											|| value.indexOf(cfg.getQuote()) != -1
+											|| value.indexOf('\r') != -1 || value.indexOf('\n') != -1;
+								}
 								break;
 
 							case MINIMAL:
@@ -260,6 +305,15 @@ public class CsvWriter implements Closeable, Flushable {
 				new StringBuilder(1).append(cfg.getQuote()),
 				new StringBuilder(2).append(cfg.getEscape()).append(cfg.getQuote())
 			);
+	}
+
+	/**
+	 * 区切り文字形式情報を返します。
+	 * @return 区切り文字形式情報
+	 * @since 2.2
+	 */
+	public CsvConfig getCfg() {
+		return cfg;
 	}
 
 	@Override

--- a/src/main/java/com/orangesignal/csv/CsvWriter.java
+++ b/src/main/java/com/orangesignal/csv/CsvWriter.java
@@ -190,9 +190,9 @@ public class CsvWriter implements Closeable, Flushable {
 
 					String value = values.get(i);
 					boolean enclose = false;	// 項目を囲み文字で囲むかどうか
-					if (value == null) {
-						// 項目値が null の場合に NULL 文字列が有効であれば NULL 文字列へ置換えます。
-						if (cfg.getNullString() == null) { 
+					if (value == null || "".equals(value)) {
+						// 項目値が null もしくは空白の場合に NULL 文字列が有効であれば NULL 文字列へ置換えます。
+						if (cfg.getNullString() == null) {
 							continue;
 						}
 						value = cfg.getNullString();

--- a/src/main/java/com/orangesignal/csv/QuotePolicy.java
+++ b/src/main/java/com/orangesignal/csv/QuotePolicy.java
@@ -32,7 +32,14 @@ public enum QuotePolicy {
 	/**
 	 * 項目内に区切り文字、囲み文字または改行文字が含まれる場合にだけ項目を囲み文字で囲むようにします。
 	 */
-	MINIMAL;
+	MINIMAL,
+
+	/**
+	 * 列全体の項目を囲み文字で囲むようにします。<p>
+	 * {@link com.orangesignal.csv.annotation.CsvColumn#columnQuote} を true にして使用して下さい。
+	 * @since 2.2
+	 */
+	COLUMN;
 
 //	NON_NUMERIC
 

--- a/src/main/java/com/orangesignal/csv/annotation/CsvColumn.java
+++ b/src/main/java/com/orangesignal/csv/annotation/CsvColumn.java
@@ -133,4 +133,13 @@ public @interface CsvColumn {
 	 */
 	String defaultValue() default "";
 
+	/**
+	 * 列全体に囲み文字を出力するかどうかを返します。<p>
+	 * {@link com.orangesignal.csv.QuotePolicy#COLUMN} と組み合わせて使います。
+	 * 
+	 * @return 列全体に囲み文字を出力するかどうか
+	 * @since 2.2
+	 */
+	boolean columnQuote() default false;
+
 }

--- a/src/test/java/com/orangesignal/csv/CsvWriterTest.java
+++ b/src/test/java/com/orangesignal/csv/CsvWriterTest.java
@@ -206,6 +206,29 @@ public class CsvWriterTest {
 */
 
 	@Test
+	public void testWriteNoNQuote() throws IOException {
+		final CsvConfig cfg = new CsvConfig(',', '"', '\\');
+		cfg.setEscapeDisabled(false);
+		cfg.setQuoteDisabled(false);
+		cfg.setQuotePolicy(QuotePolicy.COLUMN);
+		cfg.setNullString("NULL");
+		cfg.setLineSeparator("\r\n");
+
+		final StringWriter sw = new StringWriter();
+		final CsvWriter writer = new CsvWriter(sw, cfg);
+		try {
+			// Act
+			writer.writeValues(Arrays.asList(new String[]{ "aaa", "b,\"b", "ccc" }));
+			writer.writeValues(Arrays.asList(new String[]{ "zzz", "", null }));
+			writer.flush();
+			// Assert
+			assertThat(sw.getBuffer().toString(), is("aaa,\"b,\\\"b\",ccc\r\nzzz,,NULL\r\n"));
+		} finally {
+			writer.close();
+		}
+	}
+
+	@Test
 	public void testWriteValuesCsvValueException() throws IOException {
 		final CsvConfig cfg = new CsvConfig();
 		cfg.setVariableColumns(false);

--- a/src/test/java/com/orangesignal/csv/CsvWriterTest.java
+++ b/src/test/java/com/orangesignal/csv/CsvWriterTest.java
@@ -222,7 +222,7 @@ public class CsvWriterTest {
 			writer.writeValues(Arrays.asList(new String[]{ "zzz", "", null }));
 			writer.flush();
 			// Assert
-			assertThat(sw.getBuffer().toString(), is("aaa,\"b,\\\"b\",ccc\r\nzzz,,NULL\r\n"));
+			assertThat(sw.getBuffer().toString(), is("aaa,\"b,\\\"b\",ccc\r\nzzz,NULL,NULL\r\n"));
 		} finally {
 			writer.close();
 		}

--- a/src/test/java/com/orangesignal/csv/QuotePolicyTest.java
+++ b/src/test/java/com/orangesignal/csv/QuotePolicyTest.java
@@ -32,7 +32,7 @@ public class QuotePolicyTest {
 		final QuotePolicy[] values = QuotePolicy.values();
 		for (final QuotePolicy value : values) {
 			switch (value) {
-				case ALL: case MINIMAL:
+				case ALL: case MINIMAL: case COLUMN:
 					break;
 				default:
 					fail();

--- a/src/test/java/com/orangesignal/csv/handlers/CsvEntityListHandlerTest.java
+++ b/src/test/java/com/orangesignal/csv/handlers/CsvEntityListHandlerTest.java
@@ -244,7 +244,7 @@ public class CsvEntityListHandlerTest {
 		} finally {
 			writer.close();
 		}
-		assertThat(sw.getBuffer().toString(), is("No.,ラベル\r\n1,\"aaa\"\r\n2,\r\n3,NULL\r\n4,\"d\\\"d\\\"d\"\r\n"));
+		assertThat(sw.getBuffer().toString(), is("No.,ラベル\r\n1,\"aaa\"\r\n2,NULL\r\n3,NULL\r\n4,\"d\\\"d\\\"d\"\r\n"));
 	}
 
 }

--- a/src/test/java/com/orangesignal/csv/handlers/CsvEntityListHandlerTest.java
+++ b/src/test/java/com/orangesignal/csv/handlers/CsvEntityListHandlerTest.java
@@ -36,11 +36,13 @@ import com.orangesignal.csv.Constants;
 import com.orangesignal.csv.CsvConfig;
 import com.orangesignal.csv.CsvReader;
 import com.orangesignal.csv.CsvWriter;
+import com.orangesignal.csv.QuotePolicy;
 import com.orangesignal.csv.entity.Price;
 import com.orangesignal.csv.entity.Price2;
 import com.orangesignal.csv.filters.SimpleBeanFilter;
 import com.orangesignal.csv.filters.SimpleCsvNamedValueFilter;
 import com.orangesignal.csv.model.SampleBean;
+import com.orangesignal.csv.model.SampleQuote;
 
 /**
  * {@link CsvEntityListHandler} クラスの単体テストです。
@@ -215,6 +217,34 @@ public class CsvEntityListHandlerTest {
 			writer.close();
 		}
 		assertThat(sw.getBuffer().toString(), is("シンボル,名称,価格,出来高,日付,時刻\r\nGCV09,COMEX 金 2009年10月限,1\\,078,11,2008/10/06,12:00:00\r\n"));
+	}
+
+	@Test
+	public void testSaveQuote() throws Exception {
+		CsvConfig cfg = new CsvConfig(',');
+		cfg.setEscapeDisabled(false);
+		cfg.setNullString("NULL");
+		cfg.setIgnoreTrailingWhitespaces(true);
+		cfg.setIgnoreLeadingWhitespaces(true);
+		cfg.setIgnoreEmptyLines(true);
+		cfg.setLineSeparator(Constants.CRLF);
+		cfg.setQuoteDisabled(false);
+		cfg.setQuotePolicy(QuotePolicy.COLUMN);
+
+		final List<SampleQuote> list = new ArrayList<SampleQuote>();
+		list.add(new SampleQuote(1, "aaa"));
+		list.add(new SampleQuote(2, ""));
+		list.add(new SampleQuote(3, null));
+		list.add(new SampleQuote(4, "d\"d\"d"));
+
+		final StringWriter sw = new StringWriter();
+		final CsvWriter writer = new CsvWriter(sw, cfg);
+		try {
+			new CsvEntityListHandler<SampleQuote>(SampleQuote.class).save(list, writer);
+		} finally {
+			writer.close();
+		}
+		assertThat(sw.getBuffer().toString(), is("No.,ラベル\r\n1,\"aaa\"\r\n2,\r\n3,NULL\r\n4,\"d\\\"d\\\"d\"\r\n"));
 	}
 
 }

--- a/src/test/java/com/orangesignal/csv/io/CsvEntityWriterTest.java
+++ b/src/test/java/com/orangesignal/csv/io/CsvEntityWriterTest.java
@@ -35,13 +35,14 @@ import org.junit.rules.TemporaryFolder;
 import com.orangesignal.csv.Constants;
 import com.orangesignal.csv.CsvConfig;
 import com.orangesignal.csv.CsvWriter;
+import com.orangesignal.csv.QuotePolicy;
 import com.orangesignal.csv.bean.CsvEntityTemplate;
 import com.orangesignal.csv.entity.DefaultValuePrice;
 import com.orangesignal.csv.entity.Price;
-import com.orangesignal.csv.entity.Travel;
 import com.orangesignal.csv.entity.WritableEntity;
 import com.orangesignal.csv.entity.WritableNoHeaderEntity;
 import com.orangesignal.csv.filters.SimpleCsvNamedValueFilter;
+import com.orangesignal.csv.model.SampleQuote;
 
 /**
  * {@link CsvEntityWriter} クラスの単体テストです。
@@ -588,6 +589,56 @@ public class CsvEntityWriterTest {
 			writer.close();
 		}
 		assertThat(sw.getBuffer().toString(), is("シンボル,名称,価格,出来高,日付,時刻\r\nGCV09,COMEX 金 2009年10月限,1\\,078,11,2008/10/06,12:00:00\r\n"));
+	}
+
+	/**
+	 * 
+	public void testWrite() throws Exception {
+		final StringWriter sw = new StringWriter();
+		final CsvEntityWriter<Price> writer = CsvEntityWriter.newInstance(
+				new CsvWriter(sw, cfg),
+				Price.class
+			);
+		try {
+			final DateFormat df = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+			df.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
+
+			writer.write(new Price("AAAA", "aaa", 10000, 10, df.parse("2008/10/28 10:24:00")));
+			writer.write(new Price("BBBB", "bbb", null, 0, null));
+			writer.write(new Price("CCCC", "ccc", 20000, 100, df.parse("2008/10/26 14:20:10")));
+		} finally {
+			writer.close();
+		}
+		assertThat(sw.getBuffer().toString(), is("シンボル,名称,価格,出来高,日付,時刻\r\nAAAA,aaa,10\\,000,10,2008/10/28,10:24:00\r\nBBBB,bbb,NULL,0,NULL,NULL\r\nCCCC,ccc,20\\,000,100,2008/10/26,14:20:10\r\n"));
+	}	 * 
+	 */
+
+	@Test
+	public void testWriteQuote() throws Exception {
+		CsvConfig cfg = new CsvConfig(',');
+		cfg.setEscapeDisabled(false);
+		cfg.setNullString("NULL");
+		cfg.setIgnoreTrailingWhitespaces(true);
+		cfg.setIgnoreLeadingWhitespaces(true);
+		cfg.setIgnoreEmptyLines(true);
+		cfg.setLineSeparator(Constants.CRLF);
+		cfg.setQuoteDisabled(false);
+		cfg.setQuotePolicy(QuotePolicy.COLUMN);
+
+		final StringWriter sw = new StringWriter();
+		final CsvEntityWriter<SampleQuote> writer = CsvEntityWriter.newInstance(
+				new CsvWriter(sw, cfg),
+				SampleQuote.class
+			);
+		try {
+			writer.write(new SampleQuote(1, "aaa"));
+			writer.write(new SampleQuote(2, ""));
+			writer.write(new SampleQuote(3, null));
+			writer.write(new SampleQuote(4, "d\"d\"d"));
+		} finally {
+			writer.close();
+		}
+		assertThat(sw.getBuffer().toString(), is("No.,ラベル\r\n1,\"aaa\"\r\n2,\r\n3,NULL\r\n4,\"d\\\"d\\\"d\"\r\n"));
 	}
 
 	// ------------------------------------------------------------------------

--- a/src/test/java/com/orangesignal/csv/io/CsvEntityWriterTest.java
+++ b/src/test/java/com/orangesignal/csv/io/CsvEntityWriterTest.java
@@ -638,7 +638,7 @@ public class CsvEntityWriterTest {
 		} finally {
 			writer.close();
 		}
-		assertThat(sw.getBuffer().toString(), is("No.,ラベル\r\n1,\"aaa\"\r\n2,\r\n3,NULL\r\n4,\"d\\\"d\\\"d\"\r\n"));
+		assertThat(sw.getBuffer().toString(), is("No.,ラベル\r\n1,\"aaa\"\r\n2,NULL\r\n3,NULL\r\n4,\"d\\\"d\\\"d\"\r\n"));
 	}
 
 	// ------------------------------------------------------------------------

--- a/src/test/java/com/orangesignal/csv/model/SampleQuote.java
+++ b/src/test/java/com/orangesignal/csv/model/SampleQuote.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.orangesignal.csv.model;
+
+import com.orangesignal.csv.annotation.CsvColumn;
+import com.orangesignal.csv.annotation.CsvEntity;
+
+/**
+ * @author Koichi Kobayashi
+ */
+@CsvEntity
+public final class SampleQuote {
+
+	@CsvColumn(position = 0, name = "No.")
+	public Integer no;
+
+	@CsvColumn(position = 1, name = "ラベル", columnQuote = true)
+	public String label;
+
+	public SampleQuote(Integer no, String label) {
+		this.no = no;
+		this.label = label;
+	}
+}


### PR DESCRIPTION
列全体を囲み文字で囲むアノテーションとポリシーを追加しました。

CsvEntity と CsvEntityListHandler を使ってCSVを出力するときに、
項目毎に囲み文字囲むかどうかではなく、
あらかじめ決まった列に囲み文字を付けたかったため作りました。
その際、空文字の場合は囲みたくなかったので、
issue #38 の対応も合わせて入れています。