### PR TITLE
CSV を読み込むとき空文字の場合は null として読み込む設定を追加

### DIFF
--- a/src/main/java/com/orangesignal/csv/CsvConfig.java
+++ b/src/main/java/com/orangesignal/csv/CsvConfig.java
@@ -145,6 +145,11 @@ public class CsvConfig implements Serializable, Cloneable {
 	 */
 	private String lineSeparator = System.getProperty("line.separator");
 
+	/**
+	 * 空文字の場合 null に置き換えるかどうかを保持します。
+	 */
+	private boolean emptyToNull;
+
 	// ------------------------------------------------------------------------
 	// コンストラクタ
 
@@ -677,6 +682,22 @@ public class CsvConfig implements Serializable, Cloneable {
 		this.variableColumns = variableColumns;
 		return this;
 	}
+
+	/**
+	 * 空文字の場合 null に置き換えるかどうかを返します。
+	 *
+	 * @return 空文字の場合 null に置き換えるかどうか
+	 * @since 2.2.2
+	 */
+	public boolean isEmptyToNull() { return emptyToNull; }
+
+	/**
+	 * 空文字の場合 null に置き換えるかどうかを設定します。
+	 *
+	 * @param emptyToNull 空文字の場合 null に置き換えるかどうか
+	 * @since 2.2.2
+	 */
+	public void setEmptyToNull(final boolean emptyToNull) { this.emptyToNull = emptyToNull; }
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/com/orangesignal/csv/CsvReader.java
+++ b/src/main/java/com/orangesignal/csv/CsvReader.java
@@ -608,6 +608,11 @@ public class CsvReader implements Closeable {
 				value = unescapeSeparator(value);
 			}
 		}
+		if (cfg.isEmptyToNull()) {
+			if (value == null || value.length() == 0) {
+				value = null;
+			}
+		}
 
 		return new SimpleCsvToken(value, startTokenLineNumber, endTokenLineNumber, enclosed);
 	}

--- a/src/test/java/com/orangesignal/csv/handlers/StringArrayListHandlerTest.java
+++ b/src/test/java/com/orangesignal/csv/handlers/StringArrayListHandlerTest.java
@@ -166,6 +166,38 @@ public class StringArrayListHandlerTest {
 	}
 
 	@Test
+	public void testLoadNull() throws IOException {
+		final CsvConfig cfg = new CsvConfig(',', '"', '\\');
+		cfg.setNullString("NULL");
+		cfg.setBreakString("\n");
+		cfg.setIgnoreTrailingWhitespaces(true);
+		cfg.setIgnoreLeadingWhitespaces(true);
+		cfg.setIgnoreEmptyLines(true);
+		cfg.setIgnoreLinePatterns(Pattern.compile("^#.*$"));
+		cfg.setEmptyToNull(true);
+
+		final CsvReader reader = new CsvReader(new StringReader("# text/tab-separated-values   \r\n aaa , \"b\r\nb\\\\b\" , \"c\\\"cc\" \r\n zzz , yyy ,  \r\n# Copyright 2009 OrangeSignal.   "), cfg);
+		try {
+			final List<String[]> list = new StringArrayListHandler().load(reader);
+			assertThat(list.size(), is(2));
+
+			final String[] values1 = list.get(0);
+			assertThat(values1.length, is(3));
+			assertThat(values1[0], is("aaa"));
+			assertThat(values1[1], is("b\nb\\\\b"));
+			assertThat(values1[2], is("c\"cc"));
+
+			final String[] values2 = list.get(1);
+			assertThat(values2.length, is(3));
+			assertThat(values2[0], is("zzz"));
+			assertThat(values2[1], is("yyy"));
+			assertNull(values2[2]);
+		} finally {
+			reader.close();
+		}
+	}
+
+	@Test
 	public void testSave() throws IOException {
 		final CsvConfig cfg = new CsvConfig(',', '"', '\\');
 		cfg.setNullString("NULL");


### PR DESCRIPTION
CSV 上で「a,b,c,,e」のような行があった場合、
読み込むと「a,b,c,"",e」となってしまうのを「a,b,c,null,e」として読み込むように
CsvConfig に設定項目を追加しました。

CsvConfig.nullString でも「値がないことを表す文字列」を設定すれば可能ですが、
その場合は「 NULL 」などの文字列を CSV ファイルに書き込まなければならないので、
読み込むプログラム側で対応出来るようにしました。
